### PR TITLE
remove config to enable redirection (needed for fastapi)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -272,7 +272,6 @@ http {
 
             location /api {
                 proxy_pass         http://wemulateapi;
-                proxy_redirect     off;
             }
 
             location / {


### PR DESCRIPTION
FastAPI sends a redirection (HTTP 307) if there is a trailing slash (e.g. `/api/v1/connections/` to `/api/v1/connections`). The following changes enable this feature in the Nginx webserver.

Please take a look at it and merge it into the main if everything is good.