### PR TITLE
fix delay distribution used if jitter is applied

### DIFF
--- a/wemulate/utils/tcconfig.py
+++ b/wemulate/utils/tcconfig.py
@@ -53,7 +53,7 @@ def _add_jitter_command(
     parameters: Dict[str, Dict[str, int]], mean_delay: int, direction: str
 ) -> str:
     return (
-        f" --delay {mean_delay}ms --delay-distro {2 * parameters[direction][JITTER]}ms"
+        f" --delay {mean_delay}ms --delay-distro {parameters[direction][JITTER]}ms"
         if JITTER in parameters[direction]
         else ""
     )


### PR DESCRIPTION
There is no need to use twice the jitter value. Thus these changes correct this fault.
Please take a look at it and merge it into the main branch if everything looks fine for you.