### PR TITLE
Restore Controller

### DIFF
--- a/docs/dev/developer-interface.rst
+++ b/docs/dev/developer-interface.rst
@@ -28,6 +28,8 @@ Database and TC Interface
 .. autofunction:: wemulate.ext.utils.get_logical_interface_by_physical_name
 .. autofunction:: wemulate.ext.utils.get_logical_interface_by_id
 .. autofunction:: wemulate.ext.utils.get_connection_list
+.. autofunction:: wemulate.ext.utils.reset_connection
+.. autofunction:: wemulate.ext.utils.reset_device
 
 
 Setting and Configuration Interface

--- a/install/install.sh
+++ b/install/install.sh
@@ -81,21 +81,12 @@ elevate_priv() {
 create_startup_configuration() {
   info "Creating startup configuration"
   local configuration_dir="/var/lib/wemulate"
-  local path="$configuration_dir/startup.sh"
-  local conf_folder=$configuration_dir/config
   local cron_config_file=/etc/crontab
   if [ ! -d "$configuration_dir" ]; then
     sudo mkdir -p "$configuration_dir"
   fi
-  sudo bash -c "cat > "${path}"" << EOF
-#!/bin/bash
-for directory in $conf_folder/*; do
-    bash \$directory/bridge.conf
-    bash \$directory/tc.conf
-done
-EOF
   sudo bash -c "cat >> "${cron_config_file}"" << EOF
-@reboot root    bash $path >> $cron_config_file
+@reboot root    wemulate restore device >> $cron_config_file
 EOF
   completed "Startup configuration created"
 }

--- a/wemulate/controllers/restore_controller.py
+++ b/wemulate/controllers/restore_controller.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+import typer
+
+import wemulate.controllers.common as common
+import wemulate.ext.utils as utils
+from wemulate.utils.output import err_console, console
+from wemulate.core.database.setup import pre_setup_database
+
+
+app = typer.Typer(help="restore connections and parameters stored in the database")
+
+
+@app.command(help="restore all connections", no_args_is_help=False)
+def device():
+    utils.restore_device()
+    console.print("device restored")
+
+
+@app.command(help="restore a specific connection", no_args_is_help=True)
+def connection(connection_name: str = common.CONNECTION_NAME_PARAMETER):
+    common.check_if_connection_exists_in_db(connection_name)
+    utils.restore_connection(connection_name)
+    console.print(f"successfully restored connection {connection_name}")

--- a/wemulate/ext/utils/__init__.py
+++ b/wemulate/ext/utils/__init__.py
@@ -18,3 +18,4 @@ from wemulate.ext.utils.common import (
     get_current_applied_parameters,
 )
 from wemulate.ext.utils.delete import delete_connection, delete_parameter
+from wemulate.ext.utils.restore import restore_device, restore_connection

--- a/wemulate/ext/utils/restore.py
+++ b/wemulate/ext/utils/restore.py
@@ -1,0 +1,45 @@
+import wemulate.ext.utils.common as common
+import wemulate.core.database.utils as dbutils
+import wemulate.utils.tcconfig as tcutils
+
+from wemulate.core.database.models import INCOMING, OUTGOING
+
+
+def restore_device() -> None:
+    """
+    Restores all connections and tcparameters stored in the database.
+
+    Returns:
+        None
+    """
+    for connection in dbutils.get_connection_list():
+        restore_connection(connection.connection_name)
+
+
+def restore_connection(connection_name: str) -> None:
+    """
+    Restores a specific connection with its parameters stored in the database.
+
+    Args:
+        connection_name: Name of the connection which should be restored
+
+    Returns:
+        None
+    """
+    connection, current_parameter_in_db = common.get_current_applied_parameters(
+        connection_name
+    )
+
+    physical_interface1_name = dbutils.get_physical_interface_by_logical_interface_id(
+        connection.first_logical_interface_id
+    ).physical_name
+    physical_interface2_name = dbutils.get_physical_interface_by_logical_interface_id(
+        connection.second_logical_interface_id
+    ).physical_name
+    tcutils.add_connection(
+        connection_name, physical_interface1_name, physical_interface2_name
+    )
+
+    common.set_parameters_with_tc(
+        connection, current_parameter_in_db, [INCOMING, OUTGOING]
+    )

--- a/wemulate/main.py
+++ b/wemulate/main.py
@@ -13,6 +13,7 @@ from wemulate.controllers.config_controller import app as config_app
 from wemulate.controllers.show_controller import app as show_app
 from wemulate.controllers.delete_controller import app as delete_app
 from wemulate.controllers.reset_controller import app as reset_app
+from wemulate.controllers.restore_controller import app as restore_app
 from wemulate.utils.output import err_console, console
 
 
@@ -25,6 +26,7 @@ app.add_typer(config_app, name="config", no_args_is_help=True)
 app.add_typer(show_app, name="show", no_args_is_help=True)
 app.add_typer(delete_app, name="delete", no_args_is_help=True)
 app.add_typer(reset_app, name="reset", no_args_is_help=True)
+app.add_typer(restore_app, name="restore", no_args_is_help=True)
 
 
 def _get_version(value: bool) -> Optional[str]:


### PR DESCRIPTION
It brings two new functionalities:
1. `wemulate restore device`: Restores all connections (creates bridges) and their parameters (tc settings)
2. `wemulate restore connection -n <connection_name>`: Restores a specific connection (creates bridges) and their parameters (tc settings)

It solves #62 and removes the need of the config folder which currently is under `/var/lib/wemulate/config/`. 

The install script can now execute the `wemulate restore device` command instead of the old script which executes the config files.

Closes #62 