### PR TITLE
Fix linux bridge removal command

### DIFF
--- a/wemulate/utils/tcconfig.py
+++ b/wemulate/utils/tcconfig.py
@@ -156,7 +156,7 @@ def _add_interfaces_to_bridge(
 
 
 def _delete_linux_bridge(connection_name: str) -> None:
-    _execute_in_shell(f"ip link del {connection_name}")
+    _execute_in_shell(f"ip link del dev {connection_name}")
 
 
 def add_connection(


### PR DESCRIPTION
Currently it's not possible to delete some connections with special names, for example with a name `a`. It's resulting in a error 500.

The `ip link del <device-name>` command can't remove a device `a` maybe due to improper parsing of this command (or the command is ambiguous).

Example:
```
$ sudo ip link add name a type bridge
$ ip link show dev a
7: a: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether ab:cd:ef:12:34:56 brd ff:ff:ff:ff:ff:ff
$ sudo ip link del a
Command line is not complete. Try option "help"
```

But it can be fixed by using the command ``ip link del dev <device-name>`.